### PR TITLE
refactor(ui): migrate from options API to defineOptions for inheritAttrs

### DIFF
--- a/apps/ui/src/components/accounts/AccountSelect.vue
+++ b/apps/ui/src/components/accounts/AccountSelect.vue
@@ -21,6 +21,9 @@ import {
 import { AccountType } from "@maille/core/accounts";
 import UserAvatar from "../users/UserAvatar.vue";
 
+
+defineOptions({ inheritAttrs: false });
+
 const accountsStore = useAccountsStore();
 const { accounts } = storeToRefs(accountsStore);
 
@@ -87,12 +90,6 @@ watch(container, () => {
     emit("close");
   }
 });
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-};
 </script>
 
 <template>

--- a/apps/ui/src/components/activities/filters/ActivityFilterOperatorMenu.vue
+++ b/apps/ui/src/components/activities/filters/ActivityFilterOperatorMenu.vue
@@ -10,6 +10,9 @@ import {
   type ActivityFilter,
 } from "@maille/core/activities";
 
+
+defineOptions({ inheritAttrs: false });
+
 const props = defineProps<{
   modelValue: ActivityFilter["operator"] | undefined;
   field: ActivityFilter["field"];
@@ -37,12 +40,6 @@ const operators = computed<readonly string[]>(() => {
 
 const select = ref();
 defineExpose({ click: () => select.value.click() });
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-};
 </script>
 
 <template>

--- a/apps/ui/src/components/activities/filters/ActivityFilterValueMenu.vue
+++ b/apps/ui/src/components/activities/filters/ActivityFilterValueMenu.vue
@@ -2,6 +2,9 @@
 import { ref, nextTick } from "vue";
 
 import AccountSelect from "@/components/accounts/AccountSelect.vue";
+import TSelect from "@/components/designSystem/TSelect.vue";
+import TAmountInput from "@/components/designSystem/TAmountInput.vue";
+import TTextField from "@/components/designSystem/TTextField.vue";
 
 import { useActivitiesStore } from "@/stores/activities";
 
@@ -10,6 +13,9 @@ import {
   type ActivityFilter,
   ActivityFilterDateValues,
 } from "@maille/core/activities";
+
+
+defineOptions({ inheritAttrs: false });
 
 const props = defineProps<{
   modelValue: ActivityFilter["value"] | undefined;
@@ -32,12 +38,7 @@ defineExpose({
 });
 </script>
 
-<script lang="ts">
-export default {
-  components: { AccountSelect },
-  inheritAttrs: false,
-};
-</script>
+
 
 <template>
   <template v-if="field === 'date'">

--- a/apps/ui/src/components/designSystem/TAmountInput.vue
+++ b/apps/ui/src/components/designSystem/TAmountInput.vue
@@ -7,6 +7,9 @@ import { Popover, PopoverButton, PopoverPanel, Portal } from "@headlessui/vue";
 import { usePopper } from "@/hooks/use-popper";
 import { getCurrencyFormatter } from "@/utils/currency";
 
+
+defineOptions({ inheritAttrs: false });
+
 const CALCULATOR_KEYS = [
   "C",
   "plus-minus",
@@ -200,12 +203,6 @@ const handleCalculatorKey = (key: number | string, closeFunction: Function) => {
       }
       break;
   }
-};
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
 };
 </script>
 

--- a/apps/ui/src/components/designSystem/TDatePicker.vue
+++ b/apps/ui/src/components/designSystem/TDatePicker.vue
@@ -6,6 +6,9 @@ import { Menu, MenuButton, MenuItems, MenuItem, Portal } from "@headlessui/vue";
 
 import { usePopper } from "@/hooks/use-popper";
 
+
+defineOptions({ inheritAttrs: false });
+
 const WEEK_DAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
 
 const props = withDefaults(
@@ -63,12 +66,6 @@ const isValueDate = (day: number) => {
     date.value.add(day, "day").format("DD/MM/YYYY") ===
     dayjs(value.value).format("DD/MM/YYYY")
   );
-};
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
 };
 </script>
 

--- a/apps/ui/src/components/designSystem/TDeleteConfirmation.vue
+++ b/apps/ui/src/components/designSystem/TDeleteConfirmation.vue
@@ -9,6 +9,9 @@ import {
   DialogTitle,
 } from "@headlessui/vue";
 
+
+defineOptions({ inheritAttrs: false });
+
 const props = withDefaults(
   defineProps<{
     modelValue?: boolean;
@@ -34,12 +37,6 @@ const cancel = () => {
 const confirm = () => {
   emit("confirm");
   showDialog.value = false;
-};
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
 };
 </script>
 

--- a/apps/ui/src/components/designSystem/TEmojiPicker.vue
+++ b/apps/ui/src/components/designSystem/TEmojiPicker.vue
@@ -10,6 +10,9 @@ import { Menu, MenuButton, MenuItems, MenuItem, Portal } from "@headlessui/vue";
 
 import { usePopper } from "@/hooks/use-popper";
 
+
+defineOptions({ inheritAttrs: false });
+
 const props = withDefaults(
   defineProps<{
     modelValue?: string | null;
@@ -82,12 +85,6 @@ watch(container, () => {
     search.value = "";
   }
 });
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-};
 </script>
 
 <template>

--- a/apps/ui/src/components/designSystem/TMenu.vue
+++ b/apps/ui/src/components/designSystem/TMenu.vue
@@ -9,6 +9,9 @@ type MenuItemType = {
   icon?: string;
 };
 
+
+defineOptions({ inheritAttrs: false });
+
 const props = withDefaults(
   defineProps<{
     items: MenuItemType[];
@@ -24,12 +27,6 @@ const [trigger, container] = usePopper({
   placement: "bottom-end",
   modifiers: [{ name: "offset", options: { offset: [0, 4] } }],
 });
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-};
 </script>
 
 <template>

--- a/apps/ui/src/components/designSystem/TPeriodPicker.vue
+++ b/apps/ui/src/components/designSystem/TPeriodPicker.vue
@@ -6,6 +6,9 @@ import { Menu, MenuButton, MenuItems, MenuItem, Portal } from "@headlessui/vue";
 
 import { usePopper } from "@/hooks/use-popper";
 
+
+defineOptions({ inheritAttrs: false });
+
 const MONTHS = [
   "Jan.",
   "Feb.",
@@ -57,12 +60,6 @@ const isCurrentPeriod = (month: number) => {
 const isValuePeriod = (month: number) => {
   if (!value.value) return false;
   return month === value.value.month() && year.value === value.value.year();
-};
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
 };
 </script>
 

--- a/apps/ui/src/components/designSystem/TTooltip.vue
+++ b/apps/ui/src/components/designSystem/TTooltip.vue
@@ -6,6 +6,9 @@ import { Portal } from "@headlessui/vue";
 
 import { usePopper } from "@/hooks/use-popper";
 
+
+defineOptions({ inheritAttrs: false });
+
 const props = withDefaults(
   defineProps<{
     text: string;
@@ -28,12 +31,6 @@ const hoverPopover = _.debounce((): void => {
 const closePopover = (): void => {
   popoverHover.value = false;
   hoverPopover.cancel();
-};
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
 };
 </script>
 

--- a/apps/ui/src/containers/activities/AddActivityButton.vue
+++ b/apps/ui/src/containers/activities/AddActivityButton.vue
@@ -7,6 +7,8 @@ import { useHotkey } from "@/hooks/use-hotkey";
 
 import type { Movement } from "@maille/core/movements";
 
+defineOptions({ inheritAttrs: false });
+
 const props = withDefaults(
   defineProps<{
     movement?: Movement;
@@ -22,11 +24,7 @@ useHotkey(["c"], () => {
 });
 </script>
 
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-};
-</script>
+
 
 <template>
   <button

--- a/apps/ui/src/containers/activities/filters/FilterActivitiesButton.vue
+++ b/apps/ui/src/containers/activities/filters/FilterActivitiesButton.vue
@@ -8,6 +8,9 @@ import {
   type ActivityFilter,
 } from "@maille/core/activities";
 
+
+defineOptions({ inheritAttrs: false });
+
 const props = defineProps<{
   viewId: string;
 }>();
@@ -21,12 +24,6 @@ const selectField = (field: ActivityFilter["field"]) => {
     operator: undefined,
     value: undefined,
   } as ActivityFilter);
-};
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
 };
 </script>
 

--- a/apps/ui/src/containers/movements/AddMovementButton.vue
+++ b/apps/ui/src/containers/movements/AddMovementButton.vue
@@ -18,6 +18,9 @@ import type { UUID } from "crypto";
 import { createMovementMutation } from "@/mutations/movements";
 import { useHotkey } from "@/hooks/use-hotkey";
 
+
+defineOptions({ inheritAttrs: false });
+
 const movementsStore = useMovementsStore();
 const eventsStore = useEventsStore();
 
@@ -75,12 +78,6 @@ const open = () => {
 useHotkey(["c"], () => {
   open();
 });
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-};
 </script>
 
 <template>

--- a/apps/ui/src/containers/movements/ImportMovementsButton.vue
+++ b/apps/ui/src/containers/movements/ImportMovementsButton.vue
@@ -24,6 +24,9 @@ import type { UUID } from "crypto";
 dayjs.extend(customParseFormat);
 dayjs.extend(utc);
 
+
+defineOptions({ inheritAttrs: false });
+
 const props = withDefaults(
   defineProps<{
     large?: boolean;
@@ -131,12 +134,6 @@ const processFile = () => {
 
 const open = () => {
   importMovementsDialog.value.show = true;
-};
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
 };
 </script>
 

--- a/apps/ui/src/containers/periods/PeriodsMenu.vue
+++ b/apps/ui/src/containers/periods/PeriodsMenu.vue
@@ -20,6 +20,8 @@ import { usePopper } from "@/hooks/use-popper";
 import type { Period } from "@/types/periods";
 import { usePeriodsStore } from "@/stores/periods";
 
+defineOptions({ inheritAttrs: false });
+
 const router = useRouter();
 const route = useRoute();
 
@@ -85,11 +87,7 @@ const handleInput = (newDate: string) => {
 };
 </script>
 
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-};
-</script>
+
 
 <template>
   <Listbox

--- a/apps/ui/src/containers/projects/AddProjectButton.vue
+++ b/apps/ui/src/containers/projects/AddProjectButton.vue
@@ -5,6 +5,9 @@ import AddAndEditProjectModal from "./AddAndEditProjectModal.vue";
 
 import { useHotkey } from "@/hooks/use-hotkey";
 
+
+defineOptions({ inheritAttrs: false });
+
 const emit = defineEmits(["create"]);
 
 const show = ref(false);
@@ -12,12 +15,6 @@ const show = ref(false);
 useHotkey(["c"], () => {
   show.value = true;
 });
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-};
 </script>
 
 <template>


### PR DESCRIPTION
## 🔄 Refactoring

This PR modernizes the Vue.js codebase by migrating from the old options API syntax to the new `defineOptions` syntax for setting `inheritAttrs: false`.

## 📋 Changes

### What was changed
- **Before**: Components used separate `<script lang="ts">` blocks with `export default { inheritAttrs: false }`
- **After**: Components now use `defineOptions({ inheritAttrs: false })` within the setup script

### Files updated (16 total)

#### Design System Components
- `TAmountInput.vue`
- `TDatePicker.vue` 
- `TDeleteConfirmation.vue`
- `TEmojiPicker.vue`
- `TMenu.vue`
- `TPeriodPicker.vue`
- `TTooltip.vue`

#### Container Components
- `AddActivityButton.vue`
- `AddMovementButton.vue`
- `AddProjectButton.vue`
- `FilterActivitiesButton.vue`
- `ImportMovementsButton.vue`
- `PeriodsMenu.vue`

#### Other Components
- `AccountSelect.vue`
- `ActivityFilterOperatorMenu.vue`
- `ActivityFilterValueMenu.vue`

## ✅ Benefits

- **Modern syntax**: Uses Vue 3.3+ `defineOptions` macro
- **Cleaner code**: Eliminates need for separate script blocks
- **Better consistency**: All components now follow the same pattern
- **Improved maintainability**: Reduces boilerplate code
- **Future-proof**: Aligns with Vue 3 best practices

## 🧪 Testing

- ✅ All components build successfully
- ✅ No TypeScript errors introduced by the changes
- ✅ Functionality remains unchanged (only syntax migration)
- ✅ Build process completes without issues

## 🔍 Technical Details

The `defineOptions` macro was introduced in Vue 3.3 and provides a cleaner way to define component options within the `<script setup>` block. This change:

1. Removes the need for dual script blocks
2. Keeps all component logic in one place
3. Maintains the same runtime behavior
4. Is fully backward compatible

## 📝 Notes

- No functional changes to component behavior
- All existing props, emits, and functionality preserved
- Build and type checking pass successfully
- Ready for review and testing